### PR TITLE
Package auto-discovery [issue #3]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,14 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Evilnet\\Dotpay\\DotpayServiceProvider"
+            ],
+            "aliases": {
+                "Dotpay": "Evilnet\\Dotpay\\Facades\\Dotpay"
+            }
         }
     },
     "config": {


### PR DESCRIPTION
## Description

Autoładowanie providera i aliasu paczki do laravela 5.5 wzwyż.

## Motivation and context

Motywowany help-wanted. :)

## How has this been tested?

Zainstalowałem ze swojego forka, providery dobrze się wpięły, Dotpay działa bez konfiguracji w app. Trzeba tylko wykonać `php artisan package:discover` jeżeli nie ma się tego w skryptach postAutoloadDump.

## Screenshots (if appropriate)

![obraz](https://user-images.githubusercontent.com/9296448/36387272-bf3401b4-1598-11e8-9b82-6b2498bf034a.png)

