### PR TITLE
Update Client.php

### DIFF
--- a/src/DotpayApi/Client.php
+++ b/src/DotpayApi/Client.php
@@ -27,7 +27,7 @@ class Client
                 $this->password
             ],
             'headers' => ['content-type' => 'application/json', 'Accept' => 'application/json'],
-            'json' => $request->toArray()
+            'body' => json_encode($request->toArray(), 320)
         ];
         return json_decode($this->client->request($request->method(),$this->base_url.$request->path(), $options)->getBody());
     }


### PR DESCRIPTION
Fix 403 error caused by special chars like polish "ó" for example in recipient company name.
Json_encode with 320 flag is recommended by DotPay Docs (API Panelu Administracyjnego Sprzedawcy wersja 1.35.4.2, Page 7).

<!--- Provide a general summary of your changes in the Title above -->

## Description

Zmiana metody wysyłania zmiennych,

## Motivation and context

403 error. Bez tego wysłanie odbiorcy przelewu np. ze znakiem ó nie przejdzie. Niestety DotPay nie pomagał ogólnym errorem i znalezienie tego błędu zajęło mi kilka godzin. Błąd ujawnia się w nietypowych sytuacjach więc mógł nie zostać zauważony.

## How has this been tested?

Testy użytkowe.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x ] Bug fix (non-breaking change which fixes an issue)


