### PR TITLE
Update CreatePaymentLink.php

### DIFF
--- a/src/DotpayApi/Requests/CreatePaymentLink.php
+++ b/src/DotpayApi/Requests/CreatePaymentLink.php
@@ -10,7 +10,7 @@ class CreatePaymentLink extends AbstractRequest implements IRequest
     protected $currency;
     protected $description;
     protected $control;
-    protected $language;
+    // protected $language;
     protected $onlinetransfer = 1;
     protected $ch_lock = 1;
     protected $redirection_type = 0;
@@ -38,5 +38,4 @@ class CreatePaymentLink extends AbstractRequest implements IRequest
     {
         return 'api/v1/accounts/'.$this->shop_id.'/payment_links/';
     }
-
 }


### PR DESCRIPTION
Przekazanie nulla generuje błąd:

> This field may not be null.

Przekazanie języka nieobsługiwanego generuje błąd:

> "cs" is not a valid choice.

Najprościej jest nie przekazywać parametru - wtedy odpowiedzialność za wybór języka leży po stronie DotPay. Tym bardziej, że mają bug, bo wg ich supportu i dokumentacji język czeski jest obsługiwany, natomiast jak go przekazuje to dostaję error j/w. Poza tym opcjonalność tego parametru pozwoli na większą swobodę, inaczej albo biblioteka, albo użytkownik biblioteki musi we własnym zakresie sprawdzić czy dany język jest obsługiwany przez DotPay, zanim go przekaże do api. 